### PR TITLE
frontend build: fixed bug with namespaces with consecutive capital letters

### DIFF
--- a/maya/frontend/build_namespaced.py
+++ b/maya/frontend/build_namespaced.py
@@ -87,9 +87,15 @@ class PluginNamespacedCodeBuilder:
         return self.namespaced_build_path + '/' + self.plugin_name
 
 
-def camel_to_dashed(namespace):
-    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1-\2', namespace)
-    return re.sub('([a-z0-9])([A-Z])', r'\1-\2', s1).lower()
+def camel_to_dashed(camel):
+    def add_dash_before(match):
+        if match.start():
+            separator = '-'
+        else:
+            separator = ''
+        upper_case_char = match.group()
+        return separator + upper_case_char.lower()
+    return re.sub('[A-Z]', add_dash_before, camel)
 
 
 def make_namespaced_builder():

--- a/maya/tests/test_camel_to_dashed.py
+++ b/maya/tests/test_camel_to_dashed.py
@@ -1,0 +1,8 @@
+from maya.frontend.build_namespaced import camel_to_dashed
+
+
+def test():
+    assert camel_to_dashed('myplugin') == 'myplugin'
+    assert camel_to_dashed('somePluginNamespace') == 'some-plugin-namespace'
+    assert camel_to_dashed('someXYZPlugin') == 'some-x-y-z-plugin'
+    assert camel_to_dashed('XYZPlugin') == 'x-y-z-plugin'


### PR DESCRIPTION
The camel to dashed implementation was not consistent with the one from Zengine/Angular.
