### PR TITLE
update docs regarding dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Maya relies on Python, so be sure that is installed before proceeding::
 It also relies on certain `pip`_ packages::
 
     $ sudo pip install docopt
-    $ sudo pip install requests
+    $ sudo pip install requests==2.11.1
     $ sudo pip install requests[security]
 
 Alternatively, you can try the following::


### PR DESCRIPTION
This is for people installing maya nowadays (I was helping Sam today, where `maya deploy` would fail)

It seems that if you install `requests` version 2.12 you get the following error:
`AttributeError: 'X509' object has no attribute '_x509'`

There are ways to fix that but I think the best bet for now is to install an older version of the lib

See:
https://github.com/kennethreitz/requests/issues/3701#issuecomment-261717230